### PR TITLE
Remover Motivo de Venda da tabela fato_venda

### DIFF
--- a/models/gold/dim_motivo_venda.sql
+++ b/models/gold/dim_motivo_venda.sql
@@ -1,0 +1,12 @@
+with
+    dim_motivo_venda as (
+        select 
+            {{ dbt_utils.generate_surrogate_key(['ID_PEDIDO']) }} as SK_PEDIDO
+            , DESCRICAO_MOTIVO_VENDA
+            , TIPO_MOTIVO_VENDA
+        from {{ ref('silver__motivo_venda') }}
+    )
+
+
+select *
+from dim_motivo_venda

--- a/models/gold/fato_venda.sql
+++ b/models/gold/fato_venda.sql
@@ -2,6 +2,7 @@ with
     fato_venda as (
         select 
         {{ dbt_utils.generate_surrogate_key(['ID_PEDIDO_DETALHE']) }} as SK_PEDIDO_DETALHE
+        , {{ dbt_utils.generate_surrogate_key(['ID_PEDIDO']) }} as SK_PEDIDO
         , {{ dbt_utils.generate_surrogate_key(['ID_PRODUTO']) }} as SK_PRODUTO
         , {{ dbt_utils.generate_surrogate_key(['ID_CLIENTE']) }} as SK_CLIENTE
         , {{ dbt_utils.generate_surrogate_key(['ID_ENDERECO_ENVIO']) }} as SK_ENDERECO_ENVIO
@@ -9,7 +10,6 @@ with
         , DATA_ENVIO
         , NUMERO_PEDIDO
         , STATUS
-        , TIPO_MOTIVO_VENDA
         , TIPO_CARTAO_CREDITO
         , VALOR_BRUTO
         , VALOR_LIQUIDO

--- a/models/gold/fato_venda.yml
+++ b/models/gold/fato_venda.yml
@@ -8,6 +8,9 @@ models:
             - unique
             - not_null
 
+        - name: ID_PEDIDO
+          description: Identificador (chave estrangeira) do pedido
+
         - name: ID_PRODUTO
           description: Identificador (chave estrangeira) do produto
 
@@ -37,9 +40,6 @@ models:
           
         - name: STATUS
           description: Status do pedido
-          
-        - name: TIPO_MOTIVO_VENDA
-          description: Motivo de venda do pedido
           
         - name: TIPO_CARTAO_CREDITO
           description: Tipo de cartão de crédito do pedido

--- a/models/silver/silver__motivo_venda.sql
+++ b/models/silver/silver__motivo_venda.sql
@@ -1,0 +1,24 @@
+with
+    motivo_venda_pedido as (
+        select *
+        from {{ ref('bronze_erp__motivo_venda_pedido') }}
+    )
+
+    , motivo_venda as (
+        select *
+        from {{ ref('bronze_erp__motivo_venda') }}
+    )
+
+    , silver_motivo_venda as (
+        select
+            motivo_venda_pedido.ID_PEDIDO
+            , motivo_venda.DESCRICAO_MOTIVO_VENDA
+            , motivo_venda.TIPO_MOTIVO_VENDA
+        from motivo_venda_pedido
+        left join motivo_venda on (motivo_venda_pedido.ID_MOTIVO_VENDA = motivo_venda.ID_MOTIVO_VENDA)
+
+    )
+
+
+select *
+from silver_motivo_venda

--- a/models/silver/silver__motivo_venda.yml
+++ b/models/silver/silver__motivo_venda.yml
@@ -1,0 +1,17 @@
+models:
+  - name: silver__motivo_venda
+    description: Modelo que enriquece os dados de motivo de venda ao adicionar Descrição e Tipo
+    columns:
+        - name: ID_PEDIDO
+          description: Código único (chave primária) do Pedido-Produto
+          tests:
+            - not_null
+
+        - name: ID_MOTIVO_VENDA
+          description: Identificador (chave estrangeira) do motivo de venda
+
+        - name: DESCRICAO_MOTIVO_VENDA
+          description: Descrição do motivo de venda
+
+        - name: TIPO_MOTIVO_VENDA
+          description: Tipo do motivo de venda

--- a/models/silver/silver__venda.sql
+++ b/models/silver/silver__venda.sql
@@ -9,19 +9,6 @@ with
         from {{ ref('bronze_erp__venda') }}
     )
 
-    , motivo_venda_pedido as (
-        select
-            ID_PEDIDO
-            , MAX(ID_MOTIVO_VENDA) as ID_MOTIVO_VENDA
-        from {{ ref('bronze_erp__motivo_venda_pedido') }}
-        group by ID_PEDIDO
-    )
-
-    , motivo_venda as (
-        select *
-        from {{ ref('bronze_erp__motivo_venda') }}
-    )
-
     , cartao_credito as (
         select *
         from {{ ref('bronze_erp__cartao_credito') }}
@@ -30,7 +17,7 @@ with
     , silver_venda as (
         select
             venda_detalhe.ID_PEDIDO_DETALHE
-            --, venda_detalhe.ID_PEDIDO
+            , venda_detalhe.ID_PEDIDO
             , venda_detalhe.ID_PRODUTO
             , venda_detalhe.QUANTIDADE
             , venda_detalhe.PRECO_UNITARIO
@@ -43,16 +30,12 @@ with
             , venda.DATA_ENVIO
             , venda.NUMERO_PEDIDO
             , venda.STATUS
-            --, motivo_venda_pedido.ID_MOTIVO_VENDA
-            , motivo_venda.TIPO_MOTIVO_VENDA
             , cartao_credito.TIPO_CARTAO_CREDITO
             , cast(QUANTIDADE * PRECO_UNITARIO as numeric(18,6)) as VALOR_BRUTO
             , cast(QUANTIDADE * PRECO_UNITARIO * (1 - DESCONTO_PRECO_UNITARIO) as numeric(18,6)) as VALOR_LIQUIDO
         from venda_detalhe
-        left join venda               on (venda_detalhe.ID_PEDIDO = venda.ID_PEDIDO)
-        left join motivo_venda_pedido on (venda_detalhe.ID_PEDIDO = motivo_venda_pedido.ID_PEDIDO)
-        left join motivo_venda        on (motivo_venda_pedido.ID_MOTIVO_VENDA = motivo_venda.ID_MOTIVO_VENDA)
-        left join cartao_credito      on (venda.ID_CARTAO_CREDITO = cartao_credito.ID_CARTAO_CREDITO)
+        left join venda          on (venda_detalhe.ID_PEDIDO = venda.ID_PEDIDO)
+        left join cartao_credito on (venda.ID_CARTAO_CREDITO = cartao_credito.ID_CARTAO_CREDITO)
     )
 
 

--- a/models/silver/silver__venda.yml
+++ b/models/silver/silver__venda.yml
@@ -8,6 +8,9 @@ models:
             - unique
             - not_null
 
+        - name: ID_PEDIDO
+          description: Identificador (chave estrangeira) do pedido
+
         - name: ID_PRODUTO
           description: Identificador (chave estrangeira) do produto
 
@@ -37,9 +40,6 @@ models:
           
         - name: STATUS
           description: Status do pedido
-          
-        - name: TIPO_MOTIVO_VENDA
-          description: Motivo de venda do pedido
           
         - name: TIPO_CARTAO_CREDITO
           description: Tipo de cartão de crédito do pedido


### PR DESCRIPTION
Remover os campos de Motivo de Venda da fato_venda, pois um pedido pode ter 1+ motivo de venda, o que estava duplicando as linhas da fato

Criar dim_motivo_venda para relacionar posteriormente no PBI